### PR TITLE
fix v2.0.0 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 2.0.0 - 2018-01-22
+## 2.0.0 - 2019-01-22
 
 - [#11](https://github.com/westonganger/paper_trail-association_tracking/issues/11) - Remove null constraint on `version_associations.foreign_type` column which was added in `v1.1.0`. This fixes issues adding the column to existing projects who are upgrading.
 - Add generator `rails g paper_trail_association_tracking:add_foreign_type_to_version_associations` for `versions_associations.foreign_type` column for upgrading applications from `v1.0.0` or earlier.


### PR DESCRIPTION
I think v2.0.0 release date is 2019.

cf. https://github.com/westonganger/paper_trail-association_tracking/commit/8f58f6747e65edc74e35b4f065c40fabbc173ff0