### PR TITLE
Fix Travis builds (SQLite dependency for old Rails), add ActiveRecord 6 to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: ruby
 cache: bundler
 sudo: false
 
+before_install:
+  - gem update bundler
+
 notifications:
   email:
     on_success: never
@@ -12,19 +15,24 @@ addons:
 
 matrix:
   fast_finish: true
+  exclude:
+    # Rails 6 requires ruby >= 2.5.0
+    - rvm: 2.3.8
+      gemfile: gemfiles/ar_6.0.gemfile
 
 # For ruby compatibility, we test the highest and lowest minor versions only.
 # For example, if our gemspec says `required_ruby_version = ">= 2.3.0"`, and
 # ruby 2.5.0 has just been released, then we test 2.3 and 2.5, but not 2.4.
 rvm:
   - 2.5.1
-  - 2.3.6
+  - 2.3.8
    
 gemfile:
   - gemfiles/ar_4.2.gemfile
   - gemfiles/ar_5.0.gemfile
   - gemfiles/ar_5.1.gemfile
   - gemfiles/ar_5.2.gemfile
+  - gemfiles/ar_6.0.gemfile
 
 env:
   global:

--- a/Appraisals
+++ b/Appraisals
@@ -23,3 +23,8 @@ appraise "ar-5.1" do
   gem "activerecord", "~> 5.1.4"
   gem "rails-controller-testing"
 end
+
+appraise "ar-6.0" do
+  gem "activerecord", [">= 6.0.0.rc1", "< 6.1"]
+  gem "rails-controller-testing"
+end

--- a/gemfiles/ar_4.2.gemfile
+++ b/gemfiles/ar_4.2.gemfile
@@ -7,5 +7,8 @@ gem "database_cleaner", "~> 1.6"
 
 gemspec path: "../"
 
+# Rails < 5.1 requires sqlite3 ~> 1.3.6
+gem "sqlite3", "~> 1.3", "< 1.4"
+
 ENV['PT_ASSOCIATION_TRACKING'] = 'false' ### to skip the dependency on this gem, solely for testing purposes 
 gem 'paper_trail', git: 'https://github.com/paper-trail-gem/paper_trail.git'

--- a/gemfiles/ar_6.0.gemfile
+++ b/gemfiles/ar_6.0.gemfile
@@ -2,13 +2,10 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 5.0.6"
+gem "activerecord", [">= 6.0.0.rc1", "< 6.1"]
 gem "rails-controller-testing"
 
 gemspec path: "../"
-
-# Rails < 5.1 requires sqlite3 ~> 1.3.6
-gem "sqlite3", "~> 1.3", "< 1.4"
 
 ENV['PT_ASSOCIATION_TRACKING'] = 'false' ### to skip the dependency on this gem, solely for testing purposes 
 gem 'paper_trail', git: 'https://github.com/paper-trail-gem/paper_trail.git'

--- a/paper_trail-association_tracking.gemspec
+++ b/paper_trail-association_tracking.gemspec
@@ -30,9 +30,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pg", "~> 0.21.0"
   s.add_development_dependency "rack-test", [">= 0.6.3", "< 0.9"]
   s.add_development_dependency "rake", "~> 12.3"
-  s.add_development_dependency "rspec-rails", "~> 3.7.2"
-  s.add_development_dependency "rubocop", "~> 0.51.0"
-  s.add_development_dependency "rubocop-rspec", "~> 1.19.0"
+  s.add_development_dependency "rspec-rails", "~> 3.8"
+  s.add_development_dependency "rubocop", "~> 0.71.0"
+  s.add_development_dependency "rubocop-rspec", "~> 1.33.0"
   s.add_development_dependency "sqlite3", "~> 1.3"
   s.add_development_dependency "timecop", "~> 0.9.1"
 end


### PR DESCRIPTION
* Fix TravisCI builds (AR < 5.1 explicitly requires sqlite3 "~> 1.3.6", so I've changed dependency version)
* Add Rails 6 to Travis build matrix
* Bump Ruby 2.3.6 to 2.3.8 as on `paper_trail` itself