### PR TITLE
include foreign_type in index

### DIFF
--- a/lib/generators/paper_trail_association_tracking/templates/add_foreign_type_to_version_associations.rb.erb
+++ b/lib/generators/paper_trail_association_tracking/templates/add_foreign_type_to_version_associations.rb.erb
@@ -3,9 +3,19 @@
 class AddForeignTypeToVersionAssociations < ActiveRecord::Migration<%= migration_version %>
   def self.up
     add_column :version_associations, :foreign_type, :string, index: true
+    remove_index :version_associations,
+      name: "index_version_associations_on_foreign_key"
+    add_index :version_associations,
+      %i(foreign_key_name foreign_key_id foreign_type),
+      name: "index_version_associations_on_foreign_key"
   end
 
   def self.down
+    remove_index :version_associations,
+      name: "index_version_associations_on_foreign_key"
     remove_column :version_associations, :foreign_type
+    add_index :version_associations,
+      %i(foreign_key_name foreign_key_id),
+      name: "index_version_associations_on_foreign_key"
   end
 end


### PR DESCRIPTION
I upgraded an old app a couple od days ago and I went through migrations and I'd say a migration adding `foreign_type` field should recreate database index and include `foreign_type` like in `lib/generators/paper_trail_association_tracking/templates/create_version_associations.rb.erb`.