### PR TITLE
stop using subquery

### DIFF
--- a/lib/paper_trail_association_tracking/reifiers/has_many_through.rb
+++ b/lib/paper_trail_association_tracking/reifiers/has_many_through.rb
@@ -73,8 +73,8 @@ module PaperTrailAssociationTracking
         # `version_at`.
         # @api private
         def load_versions_for_hmt_association(assoc, ids, tx_id, version_at)
-          version_id_subquery = assoc.klass.paper_trail.version_class.
-            select("MIN(id)").
+          version_ids = assoc.klass.paper_trail.version_class.
+            select("MIN(id) as id").
             where("item_type = ?", assoc.klass.base_class.name).
             where("item_id IN (?)", ids).
             where(
@@ -83,8 +83,8 @@ module PaperTrailAssociationTracking
               tx_id
             ).
             group("item_id").
-            to_sql
-          ::PaperTrailAssociationTracking::Reifiers::HasMany.versions_by_id(assoc.klass, version_id_subquery)
+            map{|e| e.id}
+          ::PaperTrailAssociationTracking::Reifiers::HasMany.versions_by_id(assoc.klass, version_ids)
         end
       end
     end


### PR DESCRIPTION
@westonganger 

I want to stop using subquery because it sometimes causes high load of MySQL server.

For example, in my environment, `Model.reify(has_many: true)` executes SQL below:
```sql
SELECT `versions`.*
FROM `versions
WHERE `versions`.`id` IN (
  SELECT MIN(version_id)
  FROM `version_associations`
  INNER JOIN `versions` ON `versions`.`id` = `version_associations`.`version_id`
  WHERE (foreign_key_name = 'item_type_id')
  AND (foreign_key_id = 1)
  AND (`version_associations`.`foreign_type` = 'ItemType' OR `version_associations`.`foreign_type` IS NULL)
  AND (versions.item_type = 'Item')
  AND (created_at >= '2020-04-19 18:37:09' OR transaction_id = 2008)
  GROUP BY item_id
);
```

Explain of this SQL is:
```
+----+--------------------+----------------------+-------------+-----------------------------------------------------------------------------------+-------------------------------------------+---------+-----------------------------------------------------+------+---------------------------------------------------------------------+
| id | select_type        | table                | type        | possible_keys                                                                     | key                                       | key_len | ref                                                 | rows | Extra                                                               |
+----+--------------------+----------------------+-------------+-----------------------------------------------------------------------------------+-------------------------------------------+---------+-----------------------------------------------------+------+---------------------------------------------------------------------+
|  1 | PRIMARY            | versions             | ALL         | NULL                                                                              | NULL                                      | NULL    | NULL                                                | 1959 | Using where                                                         |
|  2 | DEPENDENT SUBQUERY | version_associations | ref_or_null | index_version_assciations_on_version_id,index_version_associations_on_foreign_key | index_version_associations_on_foreign_key | 2050    | const,const,const                                   |   31 | Using index condition; Using where; Using temporary; Using filesort |
|  2 | DEPENDENT SUBQUERY | versions             | eq_ref      | PRIMARY,index_versions_on_transaction_id,index_versions_on_item_type_item_id      | PRIMARY                                   | 4       | *******_development.version_associations.version_id |    1 | Using where                                                         |
+----+--------------------+----------------------+-------------+-----------------------------------------------------------------------------------+-------------------------------------------+---------+-----------------------------------------------------+------+---------------------------------------------------------------------+
```
As you can see, `versions` table is full scanned.
The reason why index isn't used is a specification of MySQL.

So, I separated this SQL into two parts.
```
mysql> explain SELECT `versions`.* FROM `versions` WHERE `versions`.`id` IN (SELECT MIN(version_id) FROM `version_associations` INNER JOIN `versions` ON `versions`.`id` = `version_associations`.`version_id` WHERE (foreign_key_name = 'item_type_id') AND (foreign_key_id = 1) AND (`version_associations`.`foreign_type` = 'ItemType' OR `version_associations`.`foreign_type` IS NULL) AND (versions.item_type = 'Item') AND (created_at >= '2020-04-19 18:37:09' OR transaction_id = 2008) GROUP BY item_id);
+----+-------------+----------------------+-------------+-----------------------------------------------------------------------------------+-------------------------------------------+---------+-----------------------------------------------------+------+---------------------------------------------------------------------+
| id | select_type | table                | type        | possible_keys                                                                     | key                                       | key_len | ref                                                 | rows | Extra                                                               |
+----+-------------+----------------------+-------------+-----------------------------------------------------------------------------------+-------------------------------------------+---------+-----------------------------------------------------+------+---------------------------------------------------------------------+
|  1 | SIMPLE      | version_associations | ref_or_null | index_version_assciations_on_version_id,index_version_associations_on_foreign_key | index_version_associations_on_foreign_key | 2050    | const,const,const                                   |   31 | Using index condition; Using where; Using temporary; Using filesort |
|  1 | SIMPLE      | versions             | eq_ref      | PRIMARY,index_versions_on_transaction_id,index_versions_on_item_type_item_id      | PRIMARY                                   | 4       | *******_development.version_associations.version_id |    1 | Using where                                                         |
+----+-------------+----------------------+-------------+-----------------------------------------------------------------------------------+-------------------------------------------+---------+-----------------------------------------------------+------+---------------------------------------------------------------------+
2 rows in set (0.00 sec)

mysql> explain SELECT `versions`.* FROM `versions` WHERE `versions`.`id` IN (2008, 2009, 2010, 2011, 2012, 2013);
+----+-------------+----------+-------+---------------+---------+---------+------+------+-------------+
| id | select_type | table    | type  | possible_keys | key     | key_len | ref  | rows | Extra       |
+----+-------------+----------+-------+---------------+---------+---------+------+------+-------------+
|  1 | SIMPLE      | versions | range | PRIMARY       | PRIMARY | 4       | NULL |    6 | Using where |
+----+-------------+----------+-------+---------------+---------+---------+------+------+-------------+
```