### PR TITLE
patch to load_changeset to also load has_many -> through changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,16 @@ t.amount                         # 100
 t.location.latitude              # 12.345, instead of 54.321
 ```
 
+When calling `changeset` on a `version` you can include changes to associations by specifying the following options 
+
+- To restore Has-Many-Through associations, use option `has_many_through: true`
+
+For example:
+
+```ruby
+item.versions.last.changeset(has_many_through: true)
+```
+
 # Limitations
 
 1. Only reifies the first level of associations. If you want to include nested associations simply add `:through` relationships to your model.

--- a/lib/paper_trail-association_tracking.rb
+++ b/lib/paper_trail-association_tracking.rb
@@ -50,6 +50,7 @@ module PaperTrail
 
   module VersionConcern
     include ::PaperTrailAssociationTracking::VersionConcern
+    prepend ::PaperTrailAssociationTracking::VersionConcern::ClassMethods
   end
 end
 


### PR DESCRIPTION
I had a need to try to track changes of a has many through relationship using paper trail and have leveraged some of the work in this project to do so. I'd like to start a conversation about how to best accomplish this, and also add the functionality to the other association types `has_many`, `has_one`, etc. 

Below is the start of this work, and it is working for what our case needs, but still needs better testing and some refactoring yet.