### PR TITLE
Superclass associations fix #23

### DIFF
--- a/lib/paper_trail_association_tracking/reifiers/has_many.rb
+++ b/lib/paper_trail_association_tracking/reifiers/has_many.rb
@@ -94,12 +94,18 @@ module PaperTrailAssociationTracking
         # from the point in time identified by `tx_id` or `version_at`.
         # @api private
         def load_versions_for_hm_association(assoc, model, version_table, tx_id, version_at)
+          # For STI models, associations may be defined to reference superclasses, so looking up 
+          # based on only the child-most class is not appropriate.
+          sti_model_names =  model.class.ancestors
+                                  .filter { |x| x <= model.class.base_class && x.method_defined?(assoc.name) }
+                                  .map(&:name)
+
           version_ids = ::PaperTrail::VersionAssociation.
             joins(model.class.version_association_name).
             select("MIN(version_id) as version_id").
             where("foreign_key_name = ?", assoc.foreign_key).
             where("foreign_key_id = ?", model.id).
-            where(foreign_type: [model.class.name, nil]).
+            where(foreign_type: sti_model_names + [nil]).
             where("#{version_table}.item_type = ?", assoc.klass.base_class.name).
             where("created_at >= ? OR transaction_id = ?", version_at, tx_id).
             group("item_id").

--- a/lib/paper_trail_association_tracking/reifiers/has_many.rb
+++ b/lib/paper_trail_association_tracking/reifiers/has_many.rb
@@ -97,7 +97,7 @@ module PaperTrailAssociationTracking
           # For STI models, associations may be defined to reference superclasses, so looking up 
           # based on only the child-most class is not appropriate.
           sti_model_names =  model.class.ancestors
-                                  .filter { |x| x <= model.class.base_class && x.method_defined?(assoc.name) }
+                                  .select { |x| x <= model.class.base_class && x.method_defined?(assoc.name) }
                                   .map(&:name)
 
           version_ids = ::PaperTrail::VersionAssociation.

--- a/spec/dummy_app/app/models/animal.rb
+++ b/spec/dummy_app/app/models/animal.rb
@@ -3,4 +3,5 @@
 class Animal < ActiveRecord::Base
   has_paper_trail
   self.inheritance_column = "species"
+  has_many :prey, foreign_key: :predator_id, class_name: "Hunt"
 end

--- a/spec/dummy_app/app/models/hunt.rb
+++ b/spec/dummy_app/app/models/hunt.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Hunt < ActiveRecord::Base
+  belongs_to :predator, class_name: "Animal"
+  belongs_to :prey, class_name: "Animal"
+  has_paper_trail
+end

--- a/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
@@ -215,6 +215,11 @@ class SetUpTestTables < ::ActiveRecord::Migration::Current
       t.string :object_type
       t.integer :object_id
     end
+
+    create_table :hunts, force: true do |t|
+      t.integer :predator_id
+      t.integer :prey_id
+    end
   end
 
   def down

--- a/spec/paper_trail/associations/has_many_spec.rb
+++ b/spec/paper_trail/associations/has_many_spec.rb
@@ -158,4 +158,15 @@ RSpec.describe(::PaperTrail, versioning: true) do
       expect(order).to be_marked_for_destruction
     end
   end
+
+  describe "predator, reified superclass associations from before prey is added" do
+    it "has no prey" do
+      predator = Cat.create(name: "cat_0")
+      predator.update!(name: "cat_1")
+      predator.prey.create!(prey: Dog.new(name: "dog_0"))
+      predator0 = predator.versions.last.reify(has_many: true)
+      expect(predator0.prey).to(eq([]))
+      expect(predator.prey.reload).not_to(eq([]))
+    end
+  end
 end


### PR DESCRIPTION
This fixes #23 by looking up `foreign_type` with all applicable ancestor classes (including the model class) that respond to the association. This includes a single test case via an addition to the animal test model that creates an animal <-> animal relationship a la predator/prey.