### PR TITLE
Update paper_trail-association_tracking.gemspec

### DIFF
--- a/paper_trail-association_tracking.gemspec
+++ b/paper_trail-association_tracking.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.5.0"
 
-  s.add_runtime_dependency "paper_trail", ">= 12.0"
+  s.add_runtime_dependency "paper_trail", ">= 12.1"
 
   s.add_development_dependency "appraisal"
   s.add_development_dependency "byebug"


### PR DESCRIPTION
```bash
Bundler could not find compatible versions for gem "paper_trail":
  In snapshot (Gemfile.lock):
    paper_trail (= 12.1.0)

  In Gemfile:
    paper_trail-association_tracking was resolved to 2.1.3, which depends on
      paper_trail (>= 12.0)
```