### PR TITLE
Fix the issue that reifying has_one association with "dependent: :destroy" could destroy a live record

### DIFF
--- a/lib/paper_trail_association_tracking/reifiers/has_one.rb
+++ b/lib/paper_trail_association_tracking/reifiers/has_one.rb
@@ -56,9 +56,7 @@ module PaperTrailAssociationTracking
           if options[:mark_for_destruction]
             model.send(assoc.name).mark_for_destruction if model.send(assoc.name, true)
           else
-            model.paper_trail.appear_as_new_record do
-              model.send "#{assoc.name}=", nil
-            end
+            model.association(assoc.name).target = nil
           end
         end
 

--- a/spec/dummy_app/app/models/bizzo.rb
+++ b/spec/dummy_app/app/models/bizzo.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Bizzo < ActiveRecord::Base
+  has_paper_trail
+
+  belongs_to :widget
+end

--- a/spec/dummy_app/app/models/widget.rb
+++ b/spec/dummy_app/app/models/widget.rb
@@ -4,6 +4,7 @@ class Widget < ActiveRecord::Base
   EXCLUDED_NAME = "Biglet"
   has_paper_trail
   has_one :wotsit
+  has_one :bizzo, dependent: :destroy
   has_many(:fluxors, -> { order(:name) })
   has_many :whatchamajiggers, as: :owner
   validates :name, exclusion: { in: [EXCLUDED_NAME] }

--- a/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
@@ -85,6 +85,11 @@ class SetUpTestTables < ::ActiveRecord::Migration::Current
       t.timestamps null: true, limit: 6
     end
 
+    create_table :bizzos, force: true do |t|
+      t.integer :widget_id
+      t.string  :name
+    end
+
     create_table :fluxors, force: true do |t|
       t.integer :widget_id
       t.string  :name

--- a/spec/dummy_app/db/schema.rb
+++ b/spec/dummy_app/db/schema.rb
@@ -55,6 +55,11 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.index ["foo_habtm_id"], name: "index_bar_habtms_foo_habtms_on_foo_habtm_id"
   end
 
+  create_table "bizzos", force: :cascade do |t|
+    t.integer "widget_id"
+    t.string "name"
+  end
+
   create_table "books", force: :cascade do |t|
     t.string "title"
   end

--- a/spec/paper_trail/associations/has_one_spec.rb
+++ b/spec/paper_trail/associations/has_one_spec.rb
@@ -17,6 +17,23 @@ RSpec.describe(::PaperTrail, versioning: true) do
     end
   end
 
+  describe "widget, reified from a version prior to creation of bizzo" do
+    before do
+      @widget = Widget.create(name: "widget_0")
+      @widget.update(name: "widget_1")
+      @widget.create_bizzo(name: "bizzo_0")
+      @reified = @widget.versions.last.reify(has_one: true)
+    end
+
+    it "has a nil bizzo" do
+      expect(@reified.bizzo).to be_nil
+    end
+
+    it 'does not destroy the live association' do
+      expect(@widget.reload.bizzo).not_to be_nil
+    end
+  end
+
   describe "widget, reified from a version after creation of wotsit" do
     it "has the expected wotsit" do
       widget = Widget.create(name: "widget_0")


### PR DESCRIPTION
For details, please see the issue in https://github.com/westonganger/paper_trail-association_tracking/issues/32.
