### PR TITLE
fix: foreign_type empty

### DIFF
--- a/lib/paper_trail_association_tracking/record_trail.rb
+++ b/lib/paper_trail_association_tracking/record_trail.rb
@@ -170,7 +170,7 @@ module PaperTrailAssociationTracking
 
       if assoc.options[:polymorphic]
         foreign_type = @record.send(assoc.foreign_type)
-        if foreign_type && ::PaperTrail.request.enabled_for_model?(foreign_type.constantize)
+        if foreign_type.presence && ::PaperTrail.request.enabled_for_model?(foreign_type.constantize)
           assoc_version_args[:foreign_key_id] = @record.send(assoc.foreign_key)
           assoc_version_args[:foreign_type] = foreign_type
         end


### PR DESCRIPTION
Hi guys, on this week, we upgrade version of rails to 7.0 in big legacy project on our company.
Another upgrade was paper_trail to version 14.
After upgrade this problem start happen.

The variable `foreign_type` started to resolve to string empty `""`

```
    171:   if assoc.options[:polymorphic]
    172:     foreign_type = @record.send(assoc.foreign_type)

    [1] pry(#<PaperTrail::RecordTrail>)> foreign_type
=> ""
```

In the next line ` if foreign_type && ::PaperTrail.request.enabled_for_model?(foreign_type.constantize)`
We get the this error:  `wrong constant name \n\n Object.const_get(camel_cased_word)`

The backtrace of paper_trail:
```
"backtrace":[
      "/var/app/vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.4/lib/active_support/inflector/methods.rb:280:in `const_get'",
      "/var/app/vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.4/lib/active_support/inflector/methods.rb:280:in `constantize'",
      "/var/app/vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.4/lib/active_support/core_ext/string/inflections.rb:74:in `constantize'",
      "/var/app/vendor/bundle/ruby/3.1.0/gems/paper_trail-association_tracking-2.2.1/lib/paper_trail_association_tracking/record_trail.rb:173:in `save_bt_association'",
      "/var/app/vendor/bundle/ruby/3.1.0/gems/paper_trail-association_tracking-2.2.1/lib/paper_trail_association_tracking/record_trail.rb:123:in `block in save_bt_associations'",
      "/var/app/vendor/bundle/ruby/3.1.0/gems/paper_trail-association_tracking-2.2.1/lib/paper_trail_association_tracking/record_trail.rb:122:in `each'",
      "/var/app/vendor/bundle/ruby/3.1.0/gems/paper_trail-association_tracking-2.2.1/lib/paper_trail_association_tracking/record_trail.rb:122:in `save_bt_associations'",
      "/var/app/vendor/bundle/ruby/3.1.0/gems/paper_trail-association_tracking-2.2.1/lib/paper_trail_association_tracking/record_trail.rb:115:in `save_associations'",
      "/var/app/vendor/bundle/ruby/3.1.0/gems/paper_trail-association_tracking-2.2.1/lib/paper_trail_association_tracking/record_trail.rb:79:in `record_update'",
      "/var/app/vendor/bundle/ruby/3.1.0/gems/paper_trail-14.0.0/lib/paper_trail/model_config.rb:95:in `block in on_touch'"
   ]
```

We add `.presence` method to fix this problem.

It's make senses?