### PR TITLE
FIX: klass not work for active_hash

### DIFF
--- a/lib/paper_trail_association_tracking/record_trail.rb
+++ b/lib/paper_trail_association_tracking/record_trail.rb
@@ -137,7 +137,7 @@ module PaperTrailAssociationTracking
             version_id: version.transaction_id,
             foreign_key_name: a.name,
             foreign_key_id: id,
-            foreign_type: a.klass
+            foreign_type: a.class_name.constantize
           )
         end
       end
@@ -174,9 +174,9 @@ module PaperTrailAssociationTracking
           assoc_version_args[:foreign_key_id] = @record.send(assoc.foreign_key)
           assoc_version_args[:foreign_type] = foreign_type
         end
-      elsif ::PaperTrail.request.enabled_for_model?(assoc.klass)
+      elsif ::PaperTrail.request.enabled_for_model?(assoc.class_name.constantize)
         assoc_version_args[:foreign_key_id] = @record.send(assoc.foreign_key)
-        assoc_version_args[:foreign_type] = assoc.klass
+        assoc_version_args[:foreign_type] = assoc.class_name.constantize
       end
 
       if assoc_version_args.key?(:foreign_key_id)
@@ -188,7 +188,7 @@ module PaperTrailAssociationTracking
     # @api private
     def save_habtm_association?(assoc)
       @record.class.paper_trail_save_join_tables.include?(assoc.name) ||
-        ::PaperTrail.request.enabled_for_model?(assoc.klass)
+        ::PaperTrail.request.enabled_for_model?(assoc.class_name.constantize)
     end
 
     def update_transaction_id(version)


### PR DESCRIPTION
- https://github.com/westonganger/paper_trail-association_tracking/issues/43

# problem

My code has `Product` and `ProductMaster` classes.
```ruby
def Product < ApplicationRecord
  has_paper_trail
  belongs_to_active_hash :product_master, class_name: ProductMaster
end
```

```ruby
class ProductMaster < ActiveHash::Base
  include ActiveHash::Associations

  self.data = [
    {
      id: 1,
      name: 'product_a',
      rank: 1000,
    },
    {
      id: 2,
      name: 'product_b',
      rank: 2000,
    },
    {
      id: 3,
      name: 'product_c',
      rank: 3000,
    },   
  ]

  has_many :products
end
```

When updating a `Product` instance, updating failed with following error messages.
```
Rails couldn't find a valid model for ProductMaster association.
Please provide the :class_name option on the association declaration.
If :class_name is already provided, make sure it's an ActiveRecord::Base subclass.
```

I saw `record_update` method in `lib/paper_trail_association_tracking/record_trail.rb` and debug the method.
Finally,I found the error is occurring here.

https://github.com/westonganger/paper_trail-association_tracking/blob/c8e8b2cc06f25d8563338ee08a95e6d9e2e335bf/lib/paper_trail_association_tracking/record_trail.rb#L177

`assoc` cannot return class name because `klass` is not defined in ActiveHash, I guess.


# solution suggesting
In my local environment, using `constantize` works for updating a model which have associations defined by both `belongs_to_active_hash` and `belongs_to(active_record)`.
```ruby
elsif ::PaperTrail.request.enabled_for_model?(assocclass.name.constantize)
```