### PR TITLE
Fix belongs_to polymorphic associations with "empty string" type

### DIFF
--- a/lib/paper_trail_association_tracking/record_trail.rb
+++ b/lib/paper_trail_association_tracking/record_trail.rb
@@ -170,7 +170,7 @@ module PaperTrailAssociationTracking
 
       if assoc.options[:polymorphic]
         foreign_type = @record.send(assoc.foreign_type)
-        if foreign_type && ::PaperTrail.request.enabled_for_model?(foreign_type.constantize)
+        if foreign_type.present? && ::PaperTrail.request.enabled_for_model?(foreign_type.constantize)
           assoc_version_args[:foreign_key_id] = @record.send(assoc.foreign_key)
           assoc_version_args[:foreign_type] = foreign_type
         end

--- a/spec/paper_trail/model_spec.rb
+++ b/spec/paper_trail/model_spec.rb
@@ -157,6 +157,16 @@ RSpec.describe(::PaperTrail, versioning: true) do
         it "not fail with a nil pointer on the polymorphic association" do
           @widget.save!
         end
+
+        context 'when polymorphic type is an empty string' do
+          before do
+            @widget.owner_type = ''
+          end
+
+          it 'not fail with an empty string as polymorphic type' do
+            @widget.save!
+          end
+        end
       end
 
       context "and then destroyed" do


### PR DESCRIPTION
Hi folks! 
I have encountered the following issue while using this gem.

Issue:
When a model has a `belong_to`, polymorphic and optional association, and the model has  `<polymorphic_name>_type = ''` set,  a `NameError` exception is raised when saving the model. 

Example
```
class Comment < ActiveRecord::Base
  belongs_to :post, polymorphic: true, optional: true

  has_paper_trail
end

```

When executing the following line, it fails with `NameError (wrong constant name )` 
```
Comment.new(post_type: '').save!
```

This error raises in these [lines of code](https://github.com/westonganger/paper_trail-association_tracking/blob/master/lib/paper_trail_association_tracking/record_trail.rb#L171)
```
foreign_type = @record.send(assoc.foreign_type). # returns '' (empty string)
# and then
foreign_type.constantize # raises the error
```

You can use this [script](https://gist.github.com/santir489/f5cb14970c68602eb621593946064f1d) to reproduce the issue.

 
IMO having `polymorphic_type =''`  is allowed/supported by Rails, and this gem should not break when trying to versioning an association with this characteristic.



