### PR TITLE
Fix has_many though associations when the through association is singular

### DIFF
--- a/spec/dummy_app/app/models/bizzo.rb
+++ b/spec/dummy_app/app/models/bizzo.rb
@@ -4,4 +4,5 @@ class Bizzo < ActiveRecord::Base
   has_paper_trail
 
   belongs_to :widget
+  has_many :notes, as: :object, dependent: :destroy
 end

--- a/spec/dummy_app/app/models/widget.rb
+++ b/spec/dummy_app/app/models/widget.rb
@@ -7,5 +7,6 @@ class Widget < ActiveRecord::Base
   has_one :bizzo, dependent: :destroy
   has_many(:fluxors, -> { order(:name) })
   has_many :whatchamajiggers, as: :owner
+  has_many :notes, through: :bizzo
   validates :name, exclusion: { in: [EXCLUDED_NAME] }
 end


### PR DESCRIPTION
Attempting to reify a `has_many through:` association throws an error when the `through:` association is not `has_many`.

Suppose we have these associations defined:
```ruby
class Post < ActiveRecord::Base
  has_one :content
  has_many :content_blocks, through: :content
end
```
Executing
```ruby
post.versions.last.reify(has_many: true)
```
raises `NoMethodError` [here](https://github.com/westonganger/paper_trail-association_tracking/blob/d8db2791154097f9c97759eff84f29d74c7f79c1/lib/paper_trail_association_tracking/reifiers/has_many_through.rb#L71) if `post.content` is nil and [here](https://github.com/westonganger/paper_trail-association_tracking/blob/d8db2791154097f9c97759eff84f29d74c7f79c1/lib/paper_trail_association_tracking/reifiers/has_many_through.rb#L45) otherwise.

Wrapping the through association in an Array will fix the error. However, the given example will still produce incorrect results because we aren't reifying the `content` association with `has_one: true`. Thus, the HMT association should implicitly reify the through association regardless of the options given to `reify`.