### PR TITLE
Change versions migration transaction_id to BIGINT

### DIFF
--- a/lib/generators/paper_trail_association_tracking/templates/add_transaction_id_column_to_versions.rb.erb
+++ b/lib/generators/paper_trail_association_tracking/templates/add_transaction_id_column_to_versions.rb.erb
@@ -2,7 +2,7 @@
 # schema for tracking associations.
 class AddTransactionIdColumnToVersions < ActiveRecord::Migration<%= migration_version %>
   def self.up
-    add_column :versions, :transaction_id, :integer
+    add_column :versions, :transaction_id, :bigint
     add_index :versions, [:transaction_id]
   end
 


### PR DESCRIPTION
* Rails moved to using `:bigint` for IDs to support larger ids. This change keeps it consistent with other table foreign_key id columns in Rails.