### PR TITLE
Defer the inclusion until after ActiveRecord has been fully loaded, improving booting performance and following Rails best practices

### DIFF
--- a/lib/paper_trail-association_tracking.rb
+++ b/lib/paper_trail-association_tracking.rb
@@ -10,9 +10,8 @@ require "paper_trail_association_tracking/paper_trail"
 require "paper_trail_association_tracking/version_concern"
 
 if defined?(Rails)
-  require "paper_trail/frameworks/active_record"
   require "paper_trail_association_tracking/frameworks/rails"
-elsif defined?(ActiveRecord)
+else
   require "paper_trail/frameworks/active_record"
   require "paper_trail_association_tracking/frameworks/active_record"
 end

--- a/lib/paper_trail_association_tracking/frameworks/rails/railtie.rb
+++ b/lib/paper_trail_association_tracking/frameworks/rails/railtie.rb
@@ -10,7 +10,9 @@ module PaperTrailAssociationTracking
     end
 
     config.to_prepare do
-      ::PaperTrail::Version.include(::PaperTrailAssociationTracking::VersionConcern)
+      ActiveSupport.on_load(:active_record) do
+        ::PaperTrail::Version.include(::PaperTrailAssociationTracking::VersionConcern)
+      end
     end
 
   end


### PR DESCRIPTION
## Issue Description
The current implementation references `ActiveRecord` on gem load which triggers premature loading of Active Record. This can significantly slow down application boot time, especially in development and test environments.

## Solution

Use Rails recommended [ActiveSupport.on_load(:active_record)](https://edgeapi.rubyonrails.org/classes/ActiveSupport/LazyLoadHooks.html) hook to defer module inclusion until after `ActiveRecord` is fully loaded. This improves boot performance and avoids potential load order issues in edge cases.