### PR TITLE
Defer inclusion until after active record has fully loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # CHANGELOG
 
 ### Unreleased - [View Diff](https://github.com/westonganger/paper_trail-association_tracking/compare/v2.3.0...master)
-- [#54](https://github.com/westonganger/paper_trail-association_tracking/pull/54) - Change migration for `versions.transaction_id` to BIGINT 
+- [#56](https://github.com/westonganger/paper_trail-association_tracking/pull/56) - Defer inclusion until after active record has fully loaded
+- [#54](https://github.com/westonganger/paper_trail-association_tracking/pull/54) - Change migration for `versions.transaction_id` to BIGINT
 
 ### v2.3.0 - 2025-04-17 - [View Diff](https://github.com/westonganger/paper_trail-association_tracking/compare/v2.2.1...v2.3.0)
 - [#46](https://github.com/westonganger/paper_trail-association_tracking/pull/46) - Add support for custom version association class with separate database connection

--- a/lib/paper_trail-association_tracking.rb
+++ b/lib/paper_trail-association_tracking.rb
@@ -7,14 +7,14 @@ require "paper_trail_association_tracking/reifier"
 require "paper_trail_association_tracking/record_trail"
 require "paper_trail_association_tracking/request"
 require "paper_trail_association_tracking/paper_trail"
-require "paper_trail_association_tracking/version_concern"
 
 if defined?(Rails)
-  require "paper_trail/frameworks/active_record"
-  require "paper_trail_association_tracking/frameworks/rails"
-elsif defined?(ActiveRecord)
-  require "paper_trail/frameworks/active_record"
-  require "paper_trail_association_tracking/frameworks/active_record"
+  require "paper_trail_association_tracking/frameworks/rails/railtie"
+else
+  ActiveSupport.on_load(:active_record) do
+    require "paper_trail/frameworks/active_record"
+    require "paper_trail_association_tracking/frameworks/active_record"
+  end
 end
 
 module PaperTrailAssociationTracking

--- a/lib/paper_trail_association_tracking/frameworks/active_record.rb
+++ b/lib/paper_trail_association_tracking/frameworks/active_record.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
 require "paper_trail_association_tracking/frameworks/active_record/models/paper_trail/version_association"
+
+require "paper_trail_association_tracking/version_concern"

--- a/lib/paper_trail_association_tracking/frameworks/rails.rb
+++ b/lib/paper_trail_association_tracking/frameworks/rails.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-require "paper_trail_association_tracking/frameworks/rails/railtie"

--- a/lib/paper_trail_association_tracking/frameworks/rails/railtie.rb
+++ b/lib/paper_trail_association_tracking/frameworks/rails/railtie.rb
@@ -5,12 +5,9 @@ module PaperTrailAssociationTracking
 
     initializer "paper_trail_association_tracking", after: "paper_trail" do
       ActiveSupport.on_load(:active_record) do
+        require "paper_trail/frameworks/active_record"
         require "paper_trail_association_tracking/frameworks/active_record"
       end
-    end
-
-    config.to_prepare do
-      ::PaperTrail::Version.include(::PaperTrailAssociationTracking::VersionConcern)
     end
 
   end

--- a/lib/paper_trail_association_tracking/version_concern.rb
+++ b/lib/paper_trail_association_tracking/version_concern.rb
@@ -16,3 +16,5 @@ module PaperTrailAssociationTracking
     end
   end
 end
+
+PaperTrail::Version.include(PaperTrailAssociationTracking::VersionConcern)


### PR DESCRIPTION
Supersedes #55 

## Issue Description
The current implementation references `ActiveRecord` on gem load which triggers premature loading of Active Record. This can significantly slow down application boot time, especially in development and test environments.

## Solution

Use Rails recommended [ActiveSupport.on_load(:active_record)](https://edgeapi.rubyonrails.org/classes/ActiveSupport/LazyLoadHooks.html) hook to defer module inclusion until after `ActiveRecord` is fully loaded. This improves boot performance and avoids potential load order issues in edge cases.